### PR TITLE
fix: MedicalRecordJointModel and MedicalRecordManagerModel fixed the typo; PatienId -> PatientId

### DIFF
--- a/Hospital/Managers/MedicalRecordManagerModel.cs
+++ b/Hospital/Managers/MedicalRecordManagerModel.cs
@@ -111,7 +111,7 @@ namespace Hospital.Managers
             }
         }
 
-        public async Task<ObservableCollection<MedicalRecordJointModel>> getMedicalRecord()
+        public async Task<ObservableCollection<MedicalRecordJointModel>> getMedicalRecords()
         {
             return s_medicalRecordList;
         }

--- a/Hospital/Models/MedicalRecordJointModel.cs
+++ b/Hospital/Models/MedicalRecordJointModel.cs
@@ -9,7 +9,7 @@ namespace Hospital.Models
     public class MedicalRecordJointModel
     {
         public int MedicalRecordId { get; set; }
-        public int PatienId { get; set; }
+        public int PatientId { get; set; }
         public string PatientName { get; set; }
         public int DoctorId { get; set; }
         public string DoctorName { get; set; }
@@ -18,10 +18,10 @@ namespace Hospital.Models
         public DateTime Date { get; set; }
         public string Conclusion { get; set; }
 
-        public MedicalRecordJointModel(int medicalRecordId, int patienId, string patientName, int doctorId, string doctorName, int procedureId, string procedureName, DateTime date, string conclusion)
+        public MedicalRecordJointModel(int medicalRecordId, int patientId, string patientName, int doctorId, string doctorName, int procedureId, string procedureName, DateTime date, string conclusion)
         {
             MedicalRecordId = medicalRecordId;
-            PatienId = patienId;
+            PatientId = patientId;
             PatientName = patientName;
             DoctorId = doctorId;
             DoctorName = doctorName;

--- a/Hospital/ViewModels/MedicalRecordCreationFormViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordCreationFormViewModel.cs
@@ -1,0 +1,57 @@
+﻿using Hospital.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hospital.Managers;
+using Hospital.Commands;
+
+namespace Hospital.ViewModels
+{
+    class MedicalRecordCreationFormViewModel
+    {
+        private readonly MedicalRecordManagerModel _medicalRecordManager;
+        private readonly DocumentManagerModel _documentManager;
+
+        int maxDocs = 10;
+        public ObservableCollection<string> Documents { get; private set; }
+
+
+        public MedicalRecordCreationFormViewModel(MedicalRecordManagerModel medicalRecordManager, DocumentManagerModel documentManagerModel)
+        {
+            _medicalRecordManager = medicalRecordManager;
+            _documentManager = documentManagerModel;
+            Documents = new ObservableCollection<string>();
+        }
+
+        public async Task<int> CreateMedicalRecord(AppointmentJointModel detailedAppointment, string conclusion)
+        {
+            try
+            {
+                detailedAppointment.Finished = true;
+                detailedAppointment.Date = DateTime.Now;
+                
+
+                int medicalRecordId = await _medicalRecordManager.CreateMedicalRecord(detailedAppointment);
+                return medicalRecordId;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error creating medical record: {ex.Message}");
+                return -1;
+            }
+        }
+
+        public void AddDocument(int medicalRecordId, string path)
+        {
+            Document doc = new Document(0, medicalRecordId, path);
+            if (Documents.Count < maxDocs)
+            {
+                Documents.Add(path);
+                _documentManager.AddDocumentToMedicalRecord(doc);
+            }
+        }
+    }
+}


### PR DESCRIPTION
feat: implemented MedicalRecordCreationFormViewModel

![test72](https://github.com/user-attachments/assets/6245c6da-d2a2-409c-aa16-c66d2c992885)
