### PR TITLE
#feat Creates Medical Records Details View

### DIFF
--- a/Hospital/DatabaseServices/DocumentsDatabaseService.cs
+++ b/Hospital/DatabaseServices/DocumentsDatabaseService.cs
@@ -3,6 +3,7 @@ using Hospital.Exceptions;
 using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Document = Hospital.Models.Document;
 
@@ -82,9 +83,9 @@ namespace Hospital.DatabaseServices
                 {
                     // Create a new Document object with the values from the row
                     Document document = new Document(
-                        reader.GetInt32(reader.GetOrdinal("DocumentId")),
-                        reader.GetInt32(reader.GetOrdinal("MedicalRecordId")),
-                        reader.GetString(reader.GetOrdinal("File"))
+                        reader.GetInt32(0),
+                        reader.GetInt32(1),
+                        reader.GetString(2)
                     );
                     // Add the document to the list
                     documents.Add(document);
@@ -92,10 +93,6 @@ namespace Hospital.DatabaseServices
                 // Close DB Connection
                 connection.Close();
 
-                if (documents.Count == 0)
-                {
-                    throw new DocumentNotFoundException("No documents found for the medical record with the given ID.");
-                }
                 // Return the list of Document objects
                 return documents;
             }

--- a/Hospital/Hospital.csproj
+++ b/Hospital/Hospital.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Views\AppointmentCreationForm.xaml" />
+    <None Remove="Views\MedicalRecordDetailsView.xaml" />
     <None Remove="Views\MedicalRecordsHistoryView.xaml" />
   </ItemGroup>
 
@@ -46,6 +47,11 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Managers\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\MedicalRecordDetailsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\MedicalRecordsHistoryView.xaml">

--- a/Hospital/MainWindow.xaml.cs
+++ b/Hospital/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ using Hospital.Managers;
 using Hospital.ViewModels;
 using System.Diagnostics;
 using Windows.ApplicationModel.Appointments;
+using Hospital.Exceptions;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -37,6 +38,7 @@ namespace Hospital
         private ShiftsDatabaseService? shiftService;
         private AppointmentsDatabaseService? appointmentService;
         private MedicalRecordsDatabaseService? medicalRecordsDatabaseService;
+        private DocumentDatabaseService? DocumentDatabaseService;
 
         //ManagerModels 
         private DepartmentManagerModel? DepartmentManager;
@@ -45,6 +47,7 @@ namespace Hospital
         private ShiftManagerModel? ShiftManager;
         private AppointmentManagerModel? AppointmentManager;
         private MedicalRecordManagerModel? MedicalRecordManager;
+        private DocumentManagerModel? DocumentManager;
 
 
         public MainWindow()
@@ -62,7 +65,7 @@ namespace Hospital
 
         private void Patient3_Click(object sender, RoutedEventArgs e)
         {
-            MedicalRecordsHistoryView medicalRecordsHistoryView = new MedicalRecordsHistoryView(MedicalRecordManager);
+            MedicalRecordsHistoryView medicalRecordsHistoryView = new MedicalRecordsHistoryView(MedicalRecordManager, DocumentManager);
             medicalRecordsHistoryView.Activate();
         }
 
@@ -87,6 +90,7 @@ namespace Hospital
             shiftService = new ShiftsDatabaseService();
             appointmentService = new AppointmentsDatabaseService();
             medicalRecordsDatabaseService = new MedicalRecordsDatabaseService();
+            DocumentDatabaseService = new DocumentDatabaseService();
 
             //setup manager models here
             DepartmentManager = new DepartmentManagerModel(departmentService);
@@ -95,6 +99,7 @@ namespace Hospital
             ShiftManager = new ShiftManagerModel(shiftService);
             AppointmentManager = new AppointmentManagerModel(appointmentService);
             MedicalRecordManager = new MedicalRecordManagerModel(medicalRecordsDatabaseService);
+            DocumentManager = new DocumentManagerModel(DocumentDatabaseService);
         }
 
         private void PatientScheduleButton_Click(object sender, RoutedEventArgs e)

--- a/Hospital/Managers/DocumentManagerModel.cs
+++ b/Hospital/Managers/DocumentManagerModel.cs
@@ -4,6 +4,7 @@ using Hospital.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Document = Hospital.Models.Document;
 
@@ -12,7 +13,7 @@ namespace Hospital.Managers
 {
     public class DocumentManagerModel
     {
-        public static List<Document> s_documentList { get; private set; }
+        public List<Document> s_documentList { get; private set; }
         private readonly DocumentDatabaseService _documentDBService;
 
         public DocumentManagerModel(DocumentDatabaseService dbService)
@@ -46,12 +47,7 @@ namespace Hospital.Managers
         {
             try
             {
-                List<Document> documents = await _documentDBService.GetDocumentsByMedicalRecordId(MedicalRecordId).ConfigureAwait(false);
-                s_documentList = new List<Document>(documents);
-            }
-            catch (DocumentNotFoundException)
-            {
-                throw new DocumentNotFoundException("No documents found for the medical record with the given ID.");
+                s_documentList = _documentDBService.GetDocumentsByMedicalRecordId(MedicalRecordId).Result;
             }
             catch (Exception ex)
             {

--- a/Hospital/Managers/DocumentManagerModel.cs
+++ b/Hospital/Managers/DocumentManagerModel.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO.Compression;
+using System.IO;
 using System.Threading.Tasks;
 using Document = Hospital.Models.Document;
 
@@ -22,7 +24,7 @@ namespace Hospital.Managers
             s_documentList = new List<Document>();
         }
 
-        public async Task<List<Document>> GetDocuments()
+        public List<Document> GetDocuments()
         {
             return s_documentList;
         }
@@ -43,17 +45,53 @@ namespace Hospital.Managers
             }
         }
 
-        public async Task LoadDocuments(int MedicalRecordId)
+        public void LoadDocuments(int MedicalRecordId)
         {
-            try
-            {
-                s_documentList = _documentDBService.GetDocumentsByMedicalRecordId(MedicalRecordId).Result;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error loading documents: {ex.Message}");
-            }
+            s_documentList = _documentDBService.GetDocumentsByMedicalRecordId(MedicalRecordId).Result;
         }
 
+        public async Task DownloadDocuments(int patientId)
+        {
+            List<string> filePaths = new List<string>();
+            foreach (Document document in s_documentList)
+            {
+                filePaths.Add(document.File);
+            }
+
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+                {
+                    foreach (var filePath in filePaths)
+                    {
+                        if (System.IO.File.Exists(filePath))
+                        {
+                            var fileName = Path.GetFileName(filePath);
+                            var entry = archive.CreateEntry(fileName, CompressionLevel.Fastest);
+
+                            using (var entryStream = entry.Open())
+                            {
+                                using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+                                {
+                                    await fileStream.CopyToAsync(entryStream);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            throw new DocumentNotFoundException($"Document not found at path: {filePath}");
+                        }
+                    }
+                }
+
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                var zipFile = memoryStream.ToArray();
+                string zipFileName = $"Documents_{DateTime.Now.ToString("yyyyMMddHHmmss")}.zip";
+                string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads", zipFileName);
+                File.WriteAllBytes(path, zipFile);
+
+                Process.Start("explorer.exe", "/select, " + path);
+            }
+        }
     }
 }

--- a/Hospital/Managers/MedicalRecordManagerModel.cs
+++ b/Hospital/Managers/MedicalRecordManagerModel.cs
@@ -30,6 +30,10 @@ namespace Hospital.Managers
                     .GetMedicalRecordsForPatient(patientId)
                     .ConfigureAwait(false);
                 s_medicalRecordList.Clear();
+                if (medicalRecords == null)
+                {
+                    medicalRecords = new List<MedicalRecordJointModel>();
+                }
                 foreach (MedicalRecordJointModel medicalRecord in medicalRecords)
                 {
                     s_medicalRecordList.Add(medicalRecord);

--- a/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
@@ -17,41 +17,24 @@ namespace Hospital.ViewModels
     {
         private DocumentManagerModel _documentManager;
         public MedicalRecordJointModel MedicalRecord { get; private set; }
-        public ICommand downloadDocuments { get; private set; }
         public ObservableCollection<Document> Documents { get; private set; }
 
         public MedicalRecordDetailsViewModel(MedicalRecordJointModel medicalRecord, DocumentManagerModel documentManager)
         {
             MedicalRecord = medicalRecord;
             _documentManager = documentManager;
-            _documentManager.LoadDocuments(MedicalRecord.MedicalRecordId).AsAsyncAction().Wait();
+            _documentManager.LoadDocuments(MedicalRecord.MedicalRecordId);
             Documents = new ObservableCollection<Document>(_documentManager.s_documentList);
-            downloadDocuments = new RelayCommand(DownloadDocuments);
         }
 
-        public void DownloadDocuments(Object obj)
+        public async Task OnDownloadButtonClicked()
         {
-            Debug.WriteLine("Download button clicked");
-            if (obj is List<Document> documents)
-            {
-                if (documents.Count == 0)
-                {
-                    throw new DocumentNotFoundException("No documents found");
-                }
-                foreach (Document document in documents)
-                {
-                    Debug.WriteLine($"\tDownloading document: {document.File}");
-                }
-            }
-            else 
-            {
-                throw new FormatException("Invalid object type");
-            }
+            await _documentManager.DownloadDocuments(MedicalRecord.PatientId);
         }
 
-        public void OnDownloadButtonClicked()
+        public bool getDownloadButtonIsEnabled()
         {
-            downloadDocuments.Execute(Documents.ToList());
+            return Documents.Count > 0;
         }
     }
 }

--- a/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Hospital.Commands;
+using Hospital.Exceptions;
 using Hospital.Managers;
 using Hospital.Models;
 using System;
@@ -33,16 +34,23 @@ namespace Hospital.ViewModels
             Debug.WriteLine("Download button clicked");
             if (obj is List<Document> documents)
             {
+                if (documents.Count == 0)
+                {
+                    throw new DocumentNotFoundException("No documents found");
+                }
                 foreach (Document document in documents)
                 {
                     Debug.WriteLine($"\tDownloading document: {document.File}");
                 }
             }
+            else 
+            {
+                throw new FormatException("Invalid object type");
+            }
         }
 
         public void OnDownloadButtonClicked()
         {
-            // Download the documents of the medical record
             downloadDocuments.Execute(Documents.ToList());
         }
     }

--- a/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
@@ -4,6 +4,7 @@ using Hospital.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -18,35 +19,23 @@ namespace Hospital.ViewModels
         public ICommand downloadDocuments { get; private set; }
         public ObservableCollection<Document> Documents { get; private set; }
 
-        // list of document.file
-        public string DocumentsDisplay => string.Join(", ", ListDocuments());
-
-        private List<String> ListDocuments()
-        {
-            List<String> documentList = new List<String>();
-            foreach (Document document in Documents)
-            {
-                documentList.Add(document.File);
-            }
-            return documentList;
-        }
-
         public MedicalRecordDetailsViewModel(MedicalRecordJointModel medicalRecord, DocumentManagerModel documentManager)
         {
             MedicalRecord = medicalRecord;
             _documentManager = documentManager;
-            _documentManager.LoadDocuments(MedicalRecord.MedicalRecordId);
+            _documentManager.LoadDocuments(MedicalRecord.MedicalRecordId).AsAsyncAction().Wait();
             Documents = new ObservableCollection<Document>(_documentManager.s_documentList);
             downloadDocuments = new RelayCommand(DownloadDocuments);
         }
 
         public void DownloadDocuments(Object obj)
         {
+            Debug.WriteLine("Download button clicked");
             if (obj is List<Document> documents)
             {
                 foreach (Document document in documents)
                 {
-                    Console.WriteLine($"Downloading document: {document.File}");
+                    Debug.WriteLine($"\tDownloading document: {document.File}");
                 }
             }
         }
@@ -54,6 +43,7 @@ namespace Hospital.ViewModels
         public void OnDownloadButtonClicked()
         {
             // Download the documents of the medical record
+            downloadDocuments.Execute(Documents.ToList());
         }
     }
 }

--- a/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordDetailsViewModel.cs
@@ -18,13 +18,25 @@ namespace Hospital.ViewModels
         public ICommand downloadDocuments { get; private set; }
         public ObservableCollection<Document> Documents { get; private set; }
 
+        // list of document.file
+        public string DocumentsDisplay => string.Join(", ", ListDocuments());
+
+        private List<String> ListDocuments()
+        {
+            List<String> documentList = new List<String>();
+            foreach (Document document in Documents)
+            {
+                documentList.Add(document.File);
+            }
+            return documentList;
+        }
+
         public MedicalRecordDetailsViewModel(MedicalRecordJointModel medicalRecord, DocumentManagerModel documentManager)
         {
             MedicalRecord = medicalRecord;
             _documentManager = documentManager;
-            _documentManager.LoadDocuments(MedicalRecord.MedicalRecordId).ConfigureAwait(false);
-            List<Document> documents = _documentManager.GetDocuments().ConfigureAwait(false).GetAwaiter().GetResult();
-            Documents = new ObservableCollection<Document>(documents);
+            _documentManager.LoadDocuments(MedicalRecord.MedicalRecordId);
+            Documents = new ObservableCollection<Document>(_documentManager.s_documentList);
             downloadDocuments = new RelayCommand(DownloadDocuments);
         }
 

--- a/Hospital/ViewModels/MedicalRecordsHistoryViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordsHistoryViewModel.cs
@@ -18,7 +18,6 @@ namespace Hospital.ViewModels
         private readonly DocumentManagerModel _documentManager;
 
         public List<MedicalRecordJointModel> MedicalRecords { get; private set; }
-        public ICommand ViewDetails { get; set; }
 
         public MedicalRecordsHistoryViewModel(MedicalRecordManagerModel medicalRecordManager, DocumentManagerModel documentManager)
         {
@@ -28,17 +27,13 @@ namespace Hospital.ViewModels
             int patientId = 2;
             _medicalRecordManager.LoadMedicalRecordsForPatient(patientId).Wait();
             MedicalRecords = medicalRecordManager.s_medicalRecordList;
-            ViewDetails = new RelayCommand(ShowMedicalRecordDetails);
         }
 
-        public void ShowMedicalRecordDetails(Object obj)
+        public void ShowMedicalRecordDetails(MedicalRecordJointModel medicalRecord)
         {
-            if (obj is MedicalRecordJointModel medicalRecord)
-            {
-                Console.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
-                MedicalRecordDetailsView medicalRecordDetailsView = new MedicalRecordDetailsView(medicalRecord, _documentManager);
-                medicalRecordDetailsView.Activate();
-            }
+            Console.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
+            MedicalRecordDetailsView medicalRecordDetailsView = new MedicalRecordDetailsView(medicalRecord, _documentManager);
+            medicalRecordDetailsView.Activate();
         }
     }
 }

--- a/Hospital/ViewModels/MedicalRecordsHistoryViewModel.cs
+++ b/Hospital/ViewModels/MedicalRecordsHistoryViewModel.cs
@@ -8,19 +8,22 @@ using System.Windows.Input;
 using Hospital.Commands;
 using Hospital.Managers;
 using Hospital.Models;
+using Hospital.Views;
 
 namespace Hospital.ViewModels
 {
     public class MedicalRecordsHistoryViewModel
     {
         private readonly MedicalRecordManagerModel _medicalRecordManager;
+        private readonly DocumentManagerModel _documentManager;
 
         public List<MedicalRecordJointModel> MedicalRecords { get; private set; }
         public ICommand ViewDetails { get; set; }
 
-        public MedicalRecordsHistoryViewModel(MedicalRecordManagerModel medicalRecordManager)
+        public MedicalRecordsHistoryViewModel(MedicalRecordManagerModel medicalRecordManager, DocumentManagerModel documentManager)
         {
             _medicalRecordManager = medicalRecordManager;
+            _documentManager = documentManager;
             // patient id will be substituted with the logged in user's id after login is implemented
             int patientId = 2;
             _medicalRecordManager.LoadMedicalRecordsForPatient(patientId).Wait();
@@ -33,6 +36,8 @@ namespace Hospital.ViewModels
             if (obj is MedicalRecordJointModel medicalRecord)
             {
                 Console.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
+                MedicalRecordDetailsView medicalRecordDetailsView = new MedicalRecordDetailsView(medicalRecord, _documentManager);
+                medicalRecordDetailsView.Activate();
             }
         }
     }

--- a/Hospital/Views/MedicalRecordDetailsView.xaml
+++ b/Hospital/Views/MedicalRecordDetailsView.xaml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="Hospital.Views.MedicalRecordDetailsView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:Hospital.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="MedicalRecordDetailsView">
+
+    <Grid 
+        Padding="30"
+        x:Name="MedicalRecordDetailsGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="Medical Record" FontSize="22" FontWeight="Bold" Foreground="#2C3E50" Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10"/>
+
+        <TextBlock Text="Procedure:" FontWeight="Bold" Foreground="#34495E" Grid.Row="1" Grid.Column="0" />
+        <TextBlock Text="{Binding MedicalRecord.ProcedureName}" Foreground="#2C3E50" Grid.Row="1" Grid.Column="1" />
+
+        <TextBlock Text="Department Name:" FontWeight="Bold" Foreground="#34495E" Grid.Row="2" Grid.Column="0" />
+        <TextBlock Text="{Binding MedicalRecord.DepartmentName}" Foreground="#2C3E50" Grid.Row="2" Grid.Column="1" />
+
+        <TextBlock Text="Doctor Name:" FontWeight="Bold" Foreground="#34495E" Grid.Row="3" Grid.Column="0" />
+        <TextBlock Text="{Binding MedicalRecord.DoctorName}" Foreground="#2C3E50" Grid.Row="3" Grid.Column="1" />
+
+        <TextBlock Text="Date:" FontWeight="Bold" Foreground="#34495E" Grid.Row="4" Grid.Column="0" />
+        <TextBlock Text="{Binding MedicalRecord.Date}" Foreground="#2C3E50" Grid.Row="4" Grid.Column="1" />
+
+        <TextBlock Text="Conclusion:" FontWeight="Bold" Foreground="#34495E" Grid.Row="5" Grid.Column="0" />
+        <TextBlock Text="{Binding MedicalRecord.Conclusion}" TextWrapping="Wrap" Foreground="#2C3E50" Grid.Row="5" Grid.Column="1" />
+
+        <TextBlock Text="Documents:" FontWeight="Bold" Foreground="#34495E" Grid.Row="6" Grid.Column="0" />
+        <TextBlock Text="{Binding DocumentsDisplay}" TextWrapping="Wrap" Foreground="#2C3E50" Grid.Row="6" Grid.Column="1" />
+
+        <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" Margin="0,15,0,0" HorizontalAlignment="Right">
+            <Button Content="Download" x:Name="DownloadButton" Width="120" Background="#3498DB" Foreground="White" FontWeight="Bold" Margin="0,0,10,0" />
+            <Button Content="Feedback" x:Name="FeedbackButton" Width="120" Background="#2ECC71" Foreground="White" FontWeight="Bold" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Hospital/Views/MedicalRecordDetailsView.xaml
+++ b/Hospital/Views/MedicalRecordDetailsView.xaml
@@ -6,50 +6,74 @@
     xmlns:local="clr-namespace:Hospital.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local1="using:Hospital.Models"
     mc:Ignorable="d"
-    Title="MedicalRecordDetailsView">
+    Title="Medical Record Details"
+    >
+    <StackPanel x:Name="MedicalRecordDetailsPanel">
+        <TextBlock Text="Medical Record Details" FontSize="28" FontWeight="Bold" Foreground="#2C3E50" HorizontalAlignment="Center" Margin="0,0,0,20" Padding="20"/>
+        <Grid Padding="20" HorizontalAlignment="Center" ColumnSpacing="10" RowSpacing="10" Background="LightGreen" CornerRadius="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
 
-    <Grid 
-        Padding="30"
-        x:Name="MedicalRecordDetailsGrid">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Medical Record" FontSize="22" FontWeight="Bold" Foreground="#2C3E50" Grid.Row="0" Grid.ColumnSpan="2" Margin="0,0,0,10"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
 
-        <TextBlock Text="Procedure:" FontWeight="Bold" Foreground="#34495E" Grid.Row="1" Grid.Column="0" />
-        <TextBlock Text="{Binding MedicalRecord.ProcedureName}" Foreground="#2C3E50" Grid.Row="1" Grid.Column="1" />
+            <TextBlock Text="Procedure:" FontWeight="Bold" Foreground="#34495E" Grid.Row="0" Grid.Column="0" />
+            <TextBlock Text="{Binding MedicalRecord.ProcedureName}" Foreground="#2C3E50" Grid.Row="0" Grid.Column="1" />
 
-        <TextBlock Text="Department Name:" FontWeight="Bold" Foreground="#34495E" Grid.Row="2" Grid.Column="0" />
-        <TextBlock Text="{Binding MedicalRecord.DepartmentName}" Foreground="#2C3E50" Grid.Row="2" Grid.Column="1" />
+            <TextBlock Text="Department Name:" FontWeight="Bold" Foreground="#34495E" Grid.Row="1" Grid.Column="0" />
+            <TextBlock Text="{Binding MedicalRecord.DepartmentName}" Foreground="#2C3E50" Grid.Row="1" Grid.Column="1" />
 
-        <TextBlock Text="Doctor Name:" FontWeight="Bold" Foreground="#34495E" Grid.Row="3" Grid.Column="0" />
-        <TextBlock Text="{Binding MedicalRecord.DoctorName}" Foreground="#2C3E50" Grid.Row="3" Grid.Column="1" />
+            <TextBlock Text="Doctor Name:" FontWeight="Bold" Foreground="#34495E" Grid.Row="2" Grid.Column="0" />
+            <TextBlock Text="{Binding MedicalRecord.DoctorName}" Foreground="#2C3E50" Grid.Row="2" Grid.Column="1" />
 
-        <TextBlock Text="Date:" FontWeight="Bold" Foreground="#34495E" Grid.Row="4" Grid.Column="0" />
-        <TextBlock Text="{Binding MedicalRecord.Date}" Foreground="#2C3E50" Grid.Row="4" Grid.Column="1" />
+            <TextBlock Text="Date:" FontWeight="Bold" Foreground="#34495E" Grid.Row="3" Grid.Column="0" />
+            <TextBlock Text="{Binding MedicalRecord.Date}" Foreground="#2C3E50" Grid.Row="3" Grid.Column="1" />
 
-        <TextBlock Text="Conclusion:" FontWeight="Bold" Foreground="#34495E" Grid.Row="5" Grid.Column="0" />
-        <TextBlock Text="{Binding MedicalRecord.Conclusion}" TextWrapping="Wrap" Foreground="#2C3E50" Grid.Row="5" Grid.Column="1" />
+            <TextBlock Text="Conclusion:" FontWeight="Bold" Foreground="#34495E" Grid.Row="4" Grid.Column="0" />
+            <TextBlock Text="{Binding MedicalRecord.Conclusion}" TextWrapping="Wrap" Foreground="#2C3E50" Grid.Row="4" Grid.Column="1" />
 
-        <TextBlock Text="Documents:" FontWeight="Bold" Foreground="#34495E" Grid.Row="6" Grid.Column="0" />
-        <TextBlock Text="{Binding DocumentsDisplay}" TextWrapping="Wrap" Foreground="#2C3E50" Grid.Row="6" Grid.Column="1" />
-
-        <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="1" Margin="0,15,0,0" HorizontalAlignment="Right">
-            <Button Content="Download" x:Name="DownloadButton" Width="120" Background="#3498DB" Foreground="White" FontWeight="Bold" Margin="0,0,10,0" />
-            <Button Content="Feedback" x:Name="FeedbackButton" Width="120" Background="#2ECC71" Foreground="White" FontWeight="Bold" />
-        </StackPanel>
-    </Grid>
+        </Grid>
+        <Button 
+            Content="Feedback" 
+            x:Name="FeedbackButton" 
+            Click="FeedbackButton_Click"
+            Width="120"
+            FontWeight="Bold" 
+            Margin="10" 
+            HorizontalAlignment="Center"/>
+        <Border Background="LightBlue" Padding="2" Margin="0,20,0,0" >
+            <TextBlock Text="Attached files" FontSize="20" FontWeight="Bold" Foreground="#34495E" HorizontalAlignment="Center"/>
+        </Border>
+        <ListView 
+            ItemsSource="{Binding Documents}" 
+            Width="400" 
+            SelectionMode="None"
+            Margin="10">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local1:Document">
+                    <StackPanel Padding="10" BorderBrush="LightGreen" BorderThickness="2" CornerRadius="20" Margin="2">
+                        <TextBlock Text="{x:Bind File}" FontWeight="Bold"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+        <Button 
+            Content="Download" 
+            x:Name="DownloadButton" 
+            Click="DownloadButton_Click"
+            Width="120" 
+            FontWeight="Bold" 
+            Margin="10" 
+            HorizontalAlignment="Center" />
+    </StackPanel>
 </Window>

--- a/Hospital/Views/MedicalRecordDetailsView.xaml.cs
+++ b/Hospital/Views/MedicalRecordDetailsView.xaml.cs
@@ -44,12 +44,43 @@ namespace Hospital.Views
 
         private async void DownloadButton_Click(object sender, RoutedEventArgs e)
         {
-            _viewModel.OnDownloadButtonClicked();
+            try
+            {
+                _viewModel.OnDownloadButtonClicked();
+            }
+            catch (Exception ex)
+            {
+                var validationDialog = new ContentDialog
+                {
+                    Title = "Error",
+                    Content = $"Error: {ex.Message}",
+                    CloseButtonText = "OK"
+                };
+                validationDialog.XamlRoot = this.Content.XamlRoot;
+                await validationDialog.ShowAsync();
+                return;
+            }
         }
 
         private async void FeedbackButton_Click(object sender, RoutedEventArgs e)
         {
-            Debug.WriteLine("Feedback button clicked");
+            
+            try
+            {
+                Debug.WriteLine("Feedback button clicked");
+            }
+            catch (Exception ex)
+            {
+                var validationDialog = new ContentDialog
+                {
+                    Title = "Error",
+                    Content = $"Error: {ex.Message}",
+                    CloseButtonText = "OK"
+                };
+                validationDialog.XamlRoot = this.Content.XamlRoot;
+                await validationDialog.ShowAsync();
+                return;
+            }
         }
 
         private void StyleTitleBar()

--- a/Hospital/Views/MedicalRecordDetailsView.xaml.cs
+++ b/Hospital/Views/MedicalRecordDetailsView.xaml.cs
@@ -40,13 +40,14 @@ namespace Hospital.Views
 
             _viewModel = new MedicalRecordDetailsViewModel(medicalRecordJointModel, documentManagerModel);
             this.MedicalRecordDetailsPanel.DataContext = _viewModel;
+            this.DownloadButton.IsEnabled = _viewModel.getDownloadButtonIsEnabled();
         }
 
         private async void DownloadButton_Click(object sender, RoutedEventArgs e)
         {
             try
             {
-                _viewModel.OnDownloadButtonClicked();
+                await _viewModel.OnDownloadButtonClicked();
             }
             catch (Exception ex)
             {
@@ -64,23 +65,16 @@ namespace Hospital.Views
 
         private async void FeedbackButton_Click(object sender, RoutedEventArgs e)
         {
-            
-            try
+
+            var validationDialog = new ContentDialog
             {
-                Debug.WriteLine("Feedback button clicked");
-            }
-            catch (Exception ex)
-            {
-                var validationDialog = new ContentDialog
-                {
-                    Title = "Error",
-                    Content = $"Error: {ex.Message}",
-                    CloseButtonText = "OK"
-                };
-                validationDialog.XamlRoot = this.Content.XamlRoot;
-                await validationDialog.ShowAsync();
-                return;
-            }
+                Title = "FeedbackButton_Click",
+                Content = "FeedbackButton_Click",
+                CloseButtonText = "OK"
+            };
+            validationDialog.XamlRoot = this.Content.XamlRoot;
+            await validationDialog.ShowAsync();
+            return;
         }
 
         private void StyleTitleBar()

--- a/Hospital/Views/MedicalRecordDetailsView.xaml.cs
+++ b/Hospital/Views/MedicalRecordDetailsView.xaml.cs
@@ -39,7 +39,17 @@ namespace Hospital.Views
             this.StyleTitleBar();
 
             _viewModel = new MedicalRecordDetailsViewModel(medicalRecordJointModel, documentManagerModel);
-            this.MedicalRecordDetailsGrid.DataContext = _viewModel;
+            this.MedicalRecordDetailsPanel.DataContext = _viewModel;
+        }
+
+        private async void DownloadButton_Click(object sender, RoutedEventArgs e)
+        {
+            _viewModel.OnDownloadButtonClicked();
+        }
+
+        private async void FeedbackButton_Click(object sender, RoutedEventArgs e)
+        {
+            Debug.WriteLine("Feedback button clicked");
         }
 
         private void StyleTitleBar()

--- a/Hospital/Views/MedicalRecordDetailsView.xaml.cs
+++ b/Hospital/Views/MedicalRecordDetailsView.xaml.cs
@@ -1,3 +1,4 @@
+using Hospital.Exceptions;
 using Hospital.Managers;
 using Hospital.Models;
 using Hospital.ViewModels;
@@ -5,35 +6,40 @@ using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace Hospital.Views
 {
     /// <summary>
-    /// A window where past medical records are listed for the logged in user.
+    /// A window where the details of a medical record are displayed.
     /// </summary>
-    public sealed partial class MedicalRecordsHistoryView : Window
+    public sealed partial class MedicalRecordDetailsView : Window
     {
-        private MedicalRecordsHistoryViewModel _viewModel;
+        private MedicalRecordDetailsViewModel _viewModel;
 
-        public MedicalRecordsHistoryView(MedicalRecordManagerModel medicalRecordManager, DocumentManagerModel documentManager)
+        public MedicalRecordDetailsView(MedicalRecordJointModel medicalRecordJointModel, DocumentManagerModel documentManagerModel)
         {
             this.InitializeComponent();
             this.AppWindow.Resize(new(800, 600));
             this.StyleTitleBar();
 
-            _viewModel = new MedicalRecordsHistoryViewModel(medicalRecordManager, documentManager);
-            this.MedicalRecordsPanel.DataContext = _viewModel;
-        }
-
-        private void ShowMedicalRecordDetails(object sender, RoutedEventArgs e)
-        {
-            var selectedRecord = MedicalRecordsListView.SelectedItem;
-            if (selectedRecord is MedicalRecordJointModel medicalRecord)
-            {
-                Debug.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
-                _viewModel.ShowMedicalRecordDetails(selectedRecord);
-            }
+            _viewModel = new MedicalRecordDetailsViewModel(medicalRecordJointModel, documentManagerModel);
+            this.MedicalRecordDetailsGrid.DataContext = _viewModel;
         }
 
         private void StyleTitleBar()

--- a/Hospital/Views/MedicalRecordsHistoryView.xaml
+++ b/Hospital/Views/MedicalRecordsHistoryView.xaml
@@ -14,7 +14,11 @@
     <StackPanel x:Name="MedicalRecordsPanel" Padding="20">
         <TextBlock Text="Medical Records" FontSize="24" Margin="0,0,0,10" HorizontalAlignment="Center" />
 
-        <ListView ItemsSource="{Binding MedicalRecords}" Width="400">
+        <TextBlock Text="Select Medical Record for which you want to display the details." FontSize="16" Margin="0,0,0,10" HorizontalAlignment="Center" />
+        <ListView 
+            x:Name="MedicalRecordsListView"
+            ItemsSource="{Binding MedicalRecords}" 
+            Width="400">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local1:MedicalRecordJointModel">
                     <StackPanel Padding="10" BorderBrush="Gray" BorderThickness="1"  Background="LightGreen" CornerRadius="20" Margin="10">
@@ -25,5 +29,6 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+        <Button Content="Show Details" Click="ShowMedicalRecordDetails" Margin="0,10,0,0" HorizontalAlignment="Center"/>
     </StackPanel>
 </Window>

--- a/Hospital/Views/MedicalRecordsHistoryView.xaml
+++ b/Hospital/Views/MedicalRecordsHistoryView.xaml
@@ -15,13 +15,13 @@
         <TextBlock Text="Medical Records" FontSize="24" Margin="0,0,0,10" HorizontalAlignment="Center" />
 
         <TextBlock Text="Select Medical Record for which you want to display the details." FontSize="16" Margin="0,0,0,10" HorizontalAlignment="Center" />
-        <ListView 
+        <ListView Background="LightGreen" CornerRadius="20"
             x:Name="MedicalRecordsListView"
             ItemsSource="{Binding MedicalRecords}" 
             Width="400">
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="local1:MedicalRecordJointModel">
-                    <StackPanel Padding="10" BorderBrush="Gray" BorderThickness="1"  Background="LightGreen" CornerRadius="20" Margin="10">
+                    <StackPanel Padding="10">
                         <!-- TODO replace DoctorName with DepartmentName after adding it to MedicalRecordJointModel -->
                         <TextBlock Text="{x:Bind DepartmentName}" FontWeight="Bold"/>
                         <TextBlock Text="{x:Bind Date}"/>

--- a/Hospital/Views/MedicalRecordsHistoryView.xaml.cs
+++ b/Hospital/Views/MedicalRecordsHistoryView.xaml.cs
@@ -34,8 +34,18 @@ namespace Hospital.Views
                 var selectedRecord = MedicalRecordsListView.SelectedItem;
                 if (selectedRecord is MedicalRecordJointModel medicalRecord)
                 {
-                    Debug.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
-                    _viewModel.ShowMedicalRecordDetails(selectedRecord);
+                    _viewModel.ShowMedicalRecordDetails(medicalRecord);
+                }
+                else if (selectedRecord == null)
+                {
+                    var validationDialog = new ContentDialog
+                    {
+                        Title = "No element selected",
+                        Content = "Please select a medical record to view its details.",
+                        CloseButtonText = "OK"
+                    };
+                    validationDialog.XamlRoot = this.Content.XamlRoot;
+                    await validationDialog.ShowAsync();
                 }
             }
             catch (Exception ex)

--- a/Hospital/Views/MedicalRecordsHistoryView.xaml.cs
+++ b/Hospital/Views/MedicalRecordsHistoryView.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
 using System.Diagnostics;
 
 namespace Hospital.Views
@@ -26,13 +27,28 @@ namespace Hospital.Views
             this.MedicalRecordsPanel.DataContext = _viewModel;
         }
 
-        private void ShowMedicalRecordDetails(object sender, RoutedEventArgs e)
+        private async void ShowMedicalRecordDetails(object sender, RoutedEventArgs e)
         {
-            var selectedRecord = MedicalRecordsListView.SelectedItem;
-            if (selectedRecord is MedicalRecordJointModel medicalRecord)
+            try
             {
-                Debug.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
-                _viewModel.ShowMedicalRecordDetails(selectedRecord);
+                var selectedRecord = MedicalRecordsListView.SelectedItem;
+                if (selectedRecord is MedicalRecordJointModel medicalRecord)
+                {
+                    Debug.WriteLine($"Opening details for Medical Record ID: {medicalRecord.MedicalRecordId}");
+                    _viewModel.ShowMedicalRecordDetails(selectedRecord);
+                }
+            }
+            catch (Exception ex)
+            {
+                var validationDialog = new ContentDialog
+                {
+                    Title = "Error",
+                    Content = $"Error: {ex.Message}",
+                    CloseButtonText = "OK"
+                };
+                validationDialog.XamlRoot = this.Content.XamlRoot;
+                await validationDialog.ShowAsync();
+                return;
             }
         }
 

--- a/Planning/HospitalDB.sql
+++ b/Planning/HospitalDB.sql
@@ -271,7 +271,8 @@ INSERT INTO Documents (MedicalRecordId, Files)
 VALUES
     (1, 'C:\Users\Cristi\Desktop\file1.docx'),      -- DocumentId = 1
     (2,'C:\Users\Cristi\Desktop\file1.docx'),       -- DocumentId = 2
-    (3,'C:\Users\Cristi\Desktop\file1.docx');      -- DocumentId = 3
+    (3,'C:\Users\Cristi\Desktop\file1.docx'),      -- DocumentId = 3
+    (3,'C:\Users\Cristi\Desktop\file2.docx');      -- DocumentId = 4
 
 
 -------------------------------------


### PR DESCRIPTION
# Creates Medical Records Details View

## Detailed changes:
- create the medical records details view
- link medical records history view with details view
- change how the document is created in database service
- pass document manager from MainWindow up to MedicalRecordDetailsViewModel
- add another file for medical record 3 in the db
- change the styling of medical records history window
- link UI with download button handler in viewmodel
- wait for documents to be loaded before showing the details window

## Screenshoth from running the app:
### MedicalRecordHistoryView
![image](https://github.com/user-attachments/assets/28c13b15-bbbc-4b90-b187-3c4dd2373509)
### MedicalRecordDetailsView
![image](https://github.com/user-attachments/assets/21c128e8-d93d-4b9a-8b86-1f9777c84545)
