### PR TITLE
Implemented the coloring for the time slots

### DIFF
--- a/Hospital/ViewModels/DoctorScheduleViewModel.cs
+++ b/Hospital/ViewModels/DoctorScheduleViewModel.cs
@@ -112,9 +112,22 @@ namespace Hospital.ViewModels
                 ShiftDates.Clear();
                 foreach (var shift in Shifts)
                 {
-                    var shiftDate = shift.DateTime.Date;
-                    ShiftDates.Add(new DateTimeOffset(shiftDate, TimeSpan.Zero));
+                    var shiftStartDate = shift.DateTime.Date;
+                    var shiftEndDate = shift.DateTime.Date;
+
+                    if (shift.EndTime <= shift.StartTime)
+                    {
+                        shiftEndDate = shiftEndDate.AddDays(1); 
+                    }
+
+                    ShiftDates.Add(new DateTimeOffset(shiftStartDate, TimeSpan.Zero));
+
+                    if (shiftEndDate > shiftStartDate)
+                    {
+                        ShiftDates.Add(new DateTimeOffset(shiftEndDate, TimeSpan.Zero));
+                    }
                 }
+
                 OnPropertyChanged(nameof(ShiftDates));
             }
             catch (Exception ex)

--- a/Hospital/ViewModels/DoctorScheduleViewModel.cs
+++ b/Hospital/ViewModels/DoctorScheduleViewModel.cs
@@ -162,9 +162,9 @@ namespace Hospital.ViewModels
 
         private List<TimeSlotModel> GenerateTimeSlots(DateTime date)
         {
-            List<TimeSlotModel> slots = new List<TimeSlotModel>();
+            List<TimeSlotModel> slots = new();
             DateTime startTime = date.Date;
-            DateTime endTime = startTime.AddDays(1);
+            DateTime endTime = startTime.AddDays(1); // Midnight next day
 
             var selectedAppointments = Appointments
                 .Where(a => a.Date.Date == date.Date)
@@ -175,8 +175,9 @@ namespace Hospital.ViewModels
                 {
                     var shiftStart = s.DateTime.Date + s.StartTime;
                     var shiftEnd = s.DateTime.Date + s.EndTime;
+
                     if (s.EndTime <= s.StartTime)
-                        shiftEnd = shiftEnd.AddDays(1);
+                        shiftEnd = shiftEnd.AddDays(1); // Night shift
 
                     return shiftStart < endTime && shiftEnd > startTime;
                 })
@@ -200,25 +201,21 @@ namespace Hospital.ViewModels
                     DateTime shiftEnd = s.DateTime.Date + s.EndTime;
                     if (s.EndTime <= s.StartTime)
                         shiftEnd = shiftEnd.AddDays(1);
+
                     return startTime >= shiftStart && startTime < shiftEnd;
                 });
 
-                if (isInShift)
-                {
-                    brush = new SolidColorBrush(Colors.Green);
-                }
-
                 var matchingAppointment = selectedAppointments.FirstOrDefault(a =>
-                    a.Date.Year == startTime.Year &&
-                    a.Date.Month == startTime.Month &&
-                    a.Date.Day == startTime.Day &&
-                    a.Date.Hour == startTime.Hour &&
-                    a.Date.Minute == startTime.Minute);
+                    a.Date == startTime && isInShift);
 
                 if (matchingAppointment != null)
                 {
                     slot.Appointment = matchingAppointment.ProcedureName;
                     brush = new SolidColorBrush(Colors.Orange);
+                }
+                else if (isInShift)
+                {
+                    brush = new SolidColorBrush(Colors.Green);
                 }
 
                 slot.HighlightColor = brush;
@@ -228,5 +225,6 @@ namespace Hospital.ViewModels
 
             return slots;
         }
+
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a387f3fc-3ed5-478f-a342-1901016e081b)
![image](https://github.com/user-attachments/assets/246d673b-010d-4353-8a6f-a220b2df7a7a)
Time slots will be colored green if there is a shift. If there is an appointment during the shift, the time slot will be colored orange.  The appointments which are not during a shift will not be visible.   

If the database is not connected , or the tables do not exist, an error message will be shown and the time slots will be not generate for any of the dates.