### PR TITLE
#fix: add medical records list in a scrollview

### DIFF
--- a/Hospital/Views/MedicalRecordsHistoryView.xaml
+++ b/Hospital/Views/MedicalRecordsHistoryView.xaml
@@ -10,25 +10,24 @@
     mc:Ignorable="d"
     Title="MedicalRecordsHistoryView">
 
-    
-    <StackPanel x:Name="MedicalRecordsPanel" Padding="20">
+    <Grid x:Name="MedicalRecordsPanel" RowDefinitions="Auto,Auto,*,Auto" Padding="20">
         <TextBlock Text="Medical Records" FontSize="24" Margin="0,0,0,10" HorizontalAlignment="Center" />
+        <TextBlock Grid.Row="1" Text="Select Medical Record for which you want to display the details." FontSize="16" Margin="0,0,0,10" HorizontalAlignment="Center" VerticalAlignment="Top" />
 
-        <TextBlock Text="Select Medical Record for which you want to display the details." FontSize="16" Margin="0,0,0,10" HorizontalAlignment="Center" />
-        <ListView Background="LightGreen" CornerRadius="20"
-            x:Name="MedicalRecordsListView"
-            ItemsSource="{Binding MedicalRecords}" 
-            Width="400">
-            <ListView.ItemTemplate>
-                <DataTemplate x:DataType="local1:MedicalRecordJointModel">
-                    <StackPanel Padding="10">
-                        <!-- TODO replace DoctorName with DepartmentName after adding it to MedicalRecordJointModel -->
-                        <TextBlock Text="{x:Bind DepartmentName}" FontWeight="Bold"/>
-                        <TextBlock Text="{x:Bind Date}"/>
-                    </StackPanel>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
-        <Button Content="Show Details" Click="ShowMedicalRecordDetails" Margin="0,10,0,0" HorizontalAlignment="Center"/>
-    </StackPanel>
+
+        <ScrollViewer Grid.Row="2" Margin="20, 20, 20, 20" Background="LightGreen" CornerRadius="20" Width="400">
+            <ListView x:Name="MedicalRecordsListView" ItemsSource="{Binding MedicalRecords}">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local1:MedicalRecordJointModel">
+                        <StackPanel Padding="10">
+                            <TextBlock Text="{x:Bind DepartmentName}" FontWeight="Bold"/>
+                            <TextBlock Text="{x:Bind Date}"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </ScrollViewer>
+
+        <Button Grid.Row="3" Content="Show Details" Click="ShowMedicalRecordDetails" Margin="0,10,0,0" HorizontalAlignment="Center" VerticalAlignment="Bottom"/>
+    </Grid>
 </Window>

--- a/Planning/HospitalDB.sql
+++ b/Planning/HospitalDB.sql
@@ -261,7 +261,13 @@ VALUES
     (2, 3, '2023-03-18T10:30:00', 2, 'Brain MRI results normal'), -- Mike Davis w/ Dr. Robert Johnson (Neurology)
     (2, 4, '2023-03-19T11:00:00', 3, 'Child checkup results normal'), -- Mike Davis w/ Dr. Emily Carter (Pediatrics)
     (3, 1, '2023-03-19T15:30:00', 1, 'ECG results pending'), -- Sarah Miller w/ Dr. John Smith (Cardiology)
-    (3, 2, '2023-03-20T16:00:00', 4, 'Stress test results normal'); -- Sarah Miller w/ Dr. Alice Brown (Cardiology)
+    (3, 2, '2023-03-20T16:00:00', 4, 'Stress test results normal'), -- Sarah Miller w/ Dr. Alice Brown (Cardiology)
+    (1, 1, '2023-03-17T12:30:00', 1, 'Normal ECG results'), -- Jane Doe w/ Dr. John Smith (Cardiology)
+    (1, 2, '2023-03-17T13:45:00', 4, 'Stress test results pending'), -- Jane Doe w/ Dr. Alice Brown (Cardiology)
+    (1, 3, '2023-03-18T10:30:00', 2, 'Brain MRI results normal'), -- Jane Doe w/ Dr. Robert Johnson (Neurology)
+    (1, 4, '2023-03-19T11:00:00', 3, 'Child checkup results normal'), -- Jane Doe w/ Dr. Emily Carter (Pediatrics)
+    (1, 1, '2023-03-19T15:30:00', 1, 'ECG results pending'), -- Jane Doe w/ Dr. John Smith (Cardiology)
+    (1, 2, '2023-03-20T16:00:00', 4, 'Stress test results normal'); -- Jane Doe w/ Dr. Alice Brown (Cardiology)
 
 
 -------------------------------------
@@ -427,7 +433,7 @@ ORDER BY a.DateAndTime;
 SELECT 
     a.AppointmentId,
     a.Finished,
-    a.DateAndTime,\
+    a.DateAndTime,
     d.DepartmentId,
     d.DepartmentName,
     doc.DoctorId,


### PR DESCRIPTION
- change medical record view to consist of a grid with 4 rows, out of which the row with the list is expandable
- make the list scrollable
- add multiple entries in MedicalRecords in db queries to be able to see the scrollview
- fix error in db queries